### PR TITLE
engine-api: remove useless config file for wazo-auth

### DIFF
--- a/roles/engine-api/files/wazo-auth.yml
+++ b/roles/engine-api/files/wazo-auth.yml
@@ -1,2 +1,0 @@
-service_discovery:
-  enabled: false

--- a/roles/engine-api/files/wazo-auth.yml
+++ b/roles/engine-api/files/wazo-auth.yml
@@ -1,5 +1,2 @@
-uuid: undefined
-enabled_backend_plugins:
-  ldap_user: true
 service_discovery:
   enabled: false

--- a/roles/engine-api/tasks/main.yml
+++ b/roles/engine-api/tasks/main.yml
@@ -55,14 +55,6 @@
   file:
     path: /etc/wazo-auth/conf.d
     state: directory
-- name: Add wazo-auth config
-  copy:
-    src: files/wazo-auth.yml
-    dest: /etc/wazo-auth/conf.d/50-engine-api.yml
-    owner: root
-    group: root
-    mode: 0644
-  notify: restart wazo-auth
 
 - name: Install wazo-auth
   apt:

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -8,3 +8,7 @@
       jobs:
         - wazo-ansible-install:
             nodeset: debian9-vm
+    gate:
+      jobs:
+        - wazo-ansible-install:
+            nodeset: debian9-vm


### PR DESCRIPTION
from Alexandre:

engine-api: remove useless config file for wazo-auth

reason: the specified config does not work anyway