### PR TITLE
uc-engine: fix installation order

### DIFF
--- a/roles/engine-api-init/tasks/main.yml
+++ b/roles/engine-api-init/tasks/main.yml
@@ -45,35 +45,6 @@
     - wazo-provd
     - wazo-websocketd
 
-- name: Finalize engine configuration
-  block:
-  - name: Setup engine
-    uri:
-      url: "https://{{ engine_api_host}}:{{ engine_api_port}}{{ engine_setupd_path }}/setup"
-      method: POST
-      timeout: 300
-      validate_certs: no
-      body_format: json
-      body:
-        engine_internal_address: "{{ engine_api_host }}"
-        engine_language: "{{ engine_language }}"
-        engine_license: true
-        engine_password: "{{ engine_api_root_password }}"
-      status_code: 201
-
-  - name: Create tenant
-    command: "wazo-auth-cli tenant create {{ tenant_name }}"
-
-  - name: Create API client
-    command: "wazo-auth-cli user create {{ api_client_name}} --tenant {{ tenant_name }} --password {{ api_client_password }} --purpose external_api"
-
-  - name: Create policy
-    command: "wazo-auth-cli policy create api-client-policy --tenant {{ tenant_name }} --acl 'confd.#'"
-
-  - name: Enable policy for API client
-    command: "wazo-auth-cli user add {{ api_client_name}} --policy api-client-policy"
-  when: engine_api_configure_wizard == "true"
-
 - name: Create an index.html for the home page
   become: true
   file:

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -27,3 +27,32 @@
 
 - name: Change Wazo distribution for later upgrades
   command: wazo-dist --{{ wazo_debian_repo_upgrade }}-repo {{ wazo_distribution_upgrade }}
+
+- name: Finalize engine configuration
+  block:
+  - name: Setup engine
+    uri:
+      url: "https://{{ engine_api_host}}:{{ engine_api_port}}{{ engine_setupd_path }}/setup"
+      method: POST
+      timeout: 300
+      validate_certs: no
+      body_format: json
+      body:
+        engine_internal_address: "{{ engine_api_host }}"
+        engine_language: "{{ engine_language }}"
+        engine_license: true
+        engine_password: "{{ engine_api_root_password }}"
+      status_code: 201
+
+  - name: Create tenant
+    command: "wazo-auth-cli tenant create {{ tenant_name }}"
+
+  - name: Create API client
+    command: "wazo-auth-cli user create {{ api_client_name}} --tenant {{ tenant_name }} --password {{ api_client_password }} --purpose external_api"
+
+  - name: Create policy
+    command: "wazo-auth-cli policy create api-client-policy --tenant {{ tenant_name }} --acl 'confd.#'"
+
+  - name: Enable policy for API client
+    command: "wazo-auth-cli user add {{ api_client_name}} --policy api-client-policy"
+  when: engine_api_configure_wizard == "true"

--- a/uc-engine.yml
+++ b/uc-engine.yml
@@ -23,8 +23,8 @@
   become: yes
   roles:
     - role: engine-api
-    - role: uc-engine
     - role: engine-api-init
+    - role: uc-engine
 
 - hosts: uc-ui
   become: yes


### PR DESCRIPTION
reason: wazo-auth-keys (installed by engine-api-init) is installed after
wazo-plugind (and others, installed by uc-engine) that require a key
from wazo-auth-keys, preventing the services from wazo-platform to start
correctly.