### PR TITLE
only install dropin config files if necessary

### DIFF
--- a/roles/b2bua/tasks/main.yml
+++ b/roles/b2bua/tasks/main.yml
@@ -59,6 +59,8 @@
     dest: /etc/asterisk/extensions.d/engine-api.conf
   notify:
     - reload asterisk dialplan
+  when:
+    - engine_api_host is defined
 
 - name: Install Asterisk AMI configuration
   template:
@@ -66,6 +68,10 @@
     dest: /etc/asterisk/manager.d/999-engine-api.conf
   notify:
     - reload asterisk manager
+  when:
+    - b2bua_ami_permit_client_address is defined
+    - b2bua_ami_permit_client_mask is defined
+    - b2bua_port_ami is defined
 
 - name: Install Asterisk HTTP configuration
   template:
@@ -73,6 +79,10 @@
     dest: /etc/asterisk/http.d/10-engine-api.conf
   notify:
     - reload asterisk
+  when:
+    - b2bua_listen_address is defined
+    - b2bua_port_http is defined
+    - b2bua_port_https is defined
 
 - name: Install xivo-confgend-client
   apt:
@@ -83,6 +93,9 @@
   template:
     src: templates/xivo-confgend-client.conf.j2
     dest: /etc/xivo-confgend-client/config.conf
+  when:
+    - engine_api_host is defined
+    - engine_api_port_confgend is defined
 
 - name: Create xivo-sysconfd drop-in file directory
   file:
@@ -93,6 +106,9 @@
   template:
     src: templates/xivo-sysconfd.service.j2
     dest: /etc/systemd/system/xivo-sysconfd.service.d/b2bua.conf
+  when:
+    - b2bua_listen_address is defined
+    - b2bua_port_sysconfd is defined
 
 - name: Install xivo-sysconfd
   apt:

--- a/roles/engine-api-init/tasks/main.yml
+++ b/roles/engine-api-init/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
-- name: Copy wazo-auth database preconfiguration
+- name: Create default wazo-auth database preconfiguration
+  file:
+    path: /tmp/wazo-auth.cfg
+    state: touch
+
+- name: Copy wazo-auth database preconfiguration if needed
   template:
     src: templates/wazo-auth.cfg.j2
     dest: /tmp/wazo-auth.cfg
@@ -15,6 +20,9 @@
     - engine_api_db_host is defined
     - engine_api_db_port is defined
 
+- name: Reset database options for wazo-auth package
+  shell: "echo PURGE | debconf-communicate wazo-auth"
+
 - name: Reconfigure database options for wazo-auth package
   command: debconf-set-selections /tmp/wazo-auth.cfg
 
@@ -29,6 +37,11 @@
 - name: Create service users with wazo-auth-keys
   command: wazo-auth-keys service update
 
+- name: Create default main database preconfiguration
+  file:
+    path: /tmp/xivo-manage-db.cfg
+    state: touch
+
 - name: Copy main database preconfiguration
   template:
     src: templates/xivo-manage-db.cfg.j2
@@ -42,7 +55,10 @@
     - engine_api_db_host is defined
     - engine_api_db_port is defined
 
-- name: Apply main database preconfiguration
+- name: Reset main database options for wazo-auth package
+  shell: "echo PURGE | debconf-communicate xivo-manage-db"
+
+- name: Reconfigure main database options
   command: debconf-set-selections /tmp/xivo-manage-db.cfg
 
 - name: Initialize main database

--- a/roles/engine-api-init/tasks/main.yml
+++ b/roles/engine-api-init/tasks/main.yml
@@ -3,6 +3,17 @@
   template:
     src: templates/wazo-auth.cfg.j2
     dest: /tmp/wazo-auth.cfg
+  when:
+    - engine_api_db_admin_password is defined
+    - engine_api_db_admin_user is defined
+    - engine_api_db_auth_name is defined
+    - engine_api_db_auth_password is defined
+    - engine_api_db_auth_user is defined
+    - engine_api_db_confd_name is defined
+    - engine_api_db_confd_password is defined
+    - engine_api_db_confd_user is defined
+    - engine_api_db_host is defined
+    - engine_api_db_port is defined
 
 - name: Reconfigure database options for wazo-auth package
   command: debconf-set-selections /tmp/wazo-auth.cfg
@@ -22,6 +33,14 @@
   template:
     src: templates/xivo-manage-db.cfg.j2
     dest: /tmp/xivo-manage-db.cfg
+  when:
+    - engine_api_db_admin_password is defined
+    - engine_api_db_admin_user is defined
+    - engine_api_db_confd_name is defined
+    - engine_api_db_confd_password is defined
+    - engine_api_db_confd_user is defined
+    - engine_api_db_host is defined
+    - engine_api_db_port is defined
 
 - name: Apply main database preconfiguration
   command: debconf-set-selections /tmp/xivo-manage-db.cfg

--- a/roles/engine-api/tasks/main.yml
+++ b/roles/engine-api/tasks/main.yml
@@ -89,6 +89,11 @@
     owner: root
     group: root
     mode: 0644
+  when:
+    - ari_password is defined
+    - ari_username is defined
+    - b2bua_host is defined
+    - b2bua_port_http is defined
 
 - name: Install wazo-calld
   apt:
@@ -115,6 +120,12 @@
     owner: root
     group: root
     mode: 0644
+  when:
+    - ami_password is defined
+    - ami_username is defined
+    - b2bua_host is defined
+    - b2bua_port_ami is defined
+    - b2bua_port_https is defined
 
 - name: Install wazo-amid
   apt:
@@ -141,6 +152,17 @@
     group: root
     mode: 0644
   notify: restart wazo-confd
+  when:
+    - ari_password is defined
+    - ari_username is defined
+    - b2bua_host is defined
+    - b2bua_port_http is defined
+    - b2bua_port_sysconfd is defined
+    - engine_api_db_confd_name is defined
+    - engine_api_db_confd_password is defined
+    - engine_api_db_confd_user is defined
+    - engine_api_db_host is defined
+    - engine_api_db_port is defined
 
 - name: Create xivo-dao config dir
   file:
@@ -155,6 +177,12 @@
     group: root
     mode: 0644
   notify: restart wazo-confd
+  when:
+    - engine_api_db_confd_name is defined
+    - engine_api_db_confd_password is defined
+    - engine_api_db_confd_user is defined
+    - engine_api_db_host is defined
+    - engine_api_db_port is defined
 
 - name: Install wazo-confd
   apt:
@@ -177,6 +205,14 @@
     owner: root
     group: root
     mode: 0644
+  when:
+    - engine_api_db_confd_name is defined
+    - engine_api_db_confd_user is defined
+    - engine_api_db_confd_password is defined
+    - engine_api_db_host is defined
+    - engine_api_db_port is defined
+    - engine_api_port_confgend is defined
+    - engine_api_listen_address is defined
 
 - name: Install xivo-confgend
   apt:
@@ -195,6 +231,13 @@
     owner: root
     group: root
     mode: 0644
+  when:
+    - engine_api_db_confd_name is defined
+    - engine_api_db_confd_user is defined
+    - engine_api_db_confd_password is defined
+    - engine_api_db_host is defined
+    - engine_api_db_port is defined
+    - engine_api_listen_address is defined
 
 - name: Install xivo-config
   apt:

--- a/roles/preflight_checks/tasks/main.yml
+++ b/roles/preflight_checks/tasks/main.yml
@@ -7,6 +7,9 @@
   assert:
     that:
       - engine_api_db_confd_name == engine_api_db_auth_name
+  when:
+    - engine_api_db_confd_name is defined
+    - engine_api_db_auth_name is defined
 
 - name: Assert UTF-8 locale
   shell: grep 'LANG=.*\.UTF-8"\?$' /etc/default/locale

--- a/roles/wazo_vars/defaults/main.yml
+++ b/roles/wazo_vars/defaults/main.yml
@@ -14,40 +14,46 @@ api_client_password: api-password
 engine_api_configure_wizard: false
 tenant_name: my-company
 
-engine_api_db_host: localhost
-engine_api_db_port: 5432
-engine_api_listen_address: 127.0.0.1
-
-engine_api_port_confgend: 8669
-
-engine_api_db_confd_name: asterisk
-engine_api_db_confd_password: proformatique
-engine_api_db_confd_user: asterisk
-
-engine_api_db_admin_password: superpass
-engine_api_db_admin_user: postgres
-
-engine_api_db_auth_name: asterisk
-engine_api_db_auth_password: proformatique
-engine_api_db_auth_user: asterisk
-
 engine_api_root_password: superpass
 engine_auth_path: /api/auth/0.1
 engine_confd_path: /api/confd/1.1
 engine_setupd_path: /api/setupd/1.0
 
-b2bua_ami_permit_client_address: 127.0.0.1
-b2bua_ami_permit_client_mask: 255.255.255.255
-b2bua_host: localhost
-b2bua_listen_address: 127.0.0.1
-b2bua_port_ami: 5038
-b2bua_port_http: 5039
-b2bua_port_https: 5040
-b2bua_port_sysconfd: 8668
+###################################################################################
+# The following variables must only be set for a customized value. The default
+# value (written in the comment) is handled by Debian packaging and subject to
+# change.
+###################################################################################
 
-ari_password: Nasheow8Eag
-ari_username: xivo
+# engine_api_db_host: localhost
+# engine_api_db_port: 5432
+# engine_api_listen_address: 127.0.0.1
 
-ami_password: eeCho8ied3u
-ami_username: wazo_amid
+# engine_api_port_confgend: 8669
+
+# engine_api_db_confd_name: asterisk
+# engine_api_db_confd_password: proformatique
+# engine_api_db_confd_user: asterisk
+
+# engine_api_db_admin_password: superpass
+# engine_api_db_admin_user: postgres
+
+# engine_api_db_auth_name: asterisk
+# engine_api_db_auth_password: proformatique
+# engine_api_db_auth_user: asterisk
+
+# b2bua_ami_permit_client_address: 127.0.0.1
+# b2bua_ami_permit_client_mask: 255.255.255.255
+# b2bua_host: localhost
+# b2bua_listen_address: 127.0.0.1
+# b2bua_port_ami: 5038
+# b2bua_port_http: 5039
+# b2bua_port_https: 5040
+# b2bua_port_sysconfd: 8668
+
+# ari_password: Nasheow8Eag
+# ari_username: xivo
+
+# ami_password: eeCho8ied3u
+# ami_username: wazo_amid
 


### PR DESCRIPTION
reason: wazo_amid AMI credential has been renamed, but wazo-upgrade does
not handle automatic credential renaming. So we turn to using the most
default configuration as possible, unless the admin running Ansible
explicitly gives custom settings, in which case he is responsible for
maintaining the config files during upgrade