### PR TITLE
remove unused calld config section

### DIFF
--- a/roles/engine-api/tasks/main.yml
+++ b/roles/engine-api/tasks/main.yml
@@ -100,14 +100,6 @@
     name: wazo-calld
     state: latest
 
-- name: Remove wazo-calld default config
-  file:
-    path: "/etc/wazo-calld/conf.d/{{ item }}"
-    state: absent
-  with_items:
-    - 050-xivo-consul-config.yml
-    - 050-xivo-consul-token.yml
-
 - name: Create wazo-amid config dir
   file:
     path: /etc/wazo-amid/conf.d


### PR DESCRIPTION
These files will be re-add at each upgrade. And if we do not add them,
the service will be not registered in consul

Unblock the following PR https://github.com/wazo-platform/wazo-acceptance/pull/33