### PR TITLE
restart asterisk after installing wazo-confgend

### DIFF
--- a/roles/engine-api-init/tasks/main.yml
+++ b/roles/engine-api-init/tasks/main.yml
@@ -65,6 +65,6 @@
     - wazo-amid
     - wazo-confd
     - wazo-confgend
-    - wazo-calld
+    # - wazo-calld  # the wazo-calld start should not depend from asterisk
     - wazo-provd
     - wazo-websocketd

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -32,6 +32,11 @@
     state: latest
   notify: restart wazo-setupd
 
+- name: Ensure that asterisk has been started with wazo-confgend config
+  service:
+    name: asterisk
+    state: restarted
+
 - name: Change Wazo distribution for later upgrades
   command: wazo-dist --{{ wazo_debian_repo_upgrade }}-repo {{ wazo_distribution_upgrade }}
 

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -37,6 +37,11 @@
     name: asterisk
     state: restarted
 
+- name: Start wazo-calld that can be not restarted if asterisk wasn't not fully configured
+  service:
+    name: wazo-calld
+    state: restarted
+
 - name: Change Wazo distribution for later upgrades
   command: wazo-dist --{{ wazo_debian_repo_upgrade }}-repo {{ wazo_distribution_upgrade }}
 


### PR DESCRIPTION
reason: the failing workflow
* asterisk start with no module loaded
* wazo-confgend is installed
* wazo-calld is restarted, but wazo-calld need an asterisk properly
  configured to start, which is not really cloud native
* Boom

asterisk need to be restarted after installing wazo-confgend