### PR TITLE
validate_uc: check installed version when using archive repo

### DIFF
--- a/roles/validate_uc/tasks/main.yml
+++ b/roles/validate_uc/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: check version
   shell: "vers={{ wazo_distribution }}; echo ${vers##*-} $(cat /usr/share/wazo/WAZO-VERSION); test ${vers##*-} = $(cat /usr/share/wazo/WAZO-VERSION)"
-  when: wazo_distribution != "wazo-dev-buster"
+  when: wazo_debian_repo == "archive"
 
 - name: Check that wazo-auth is listed in Consul services
   shell: "consul catalog services|grep wazo-auth"


### PR DESCRIPTION
Why:

* Installing from wazo-rc-buster or pelican-buster would fail the check