### PR TITLE
avoid cast engine_api_root_pwd to int

### DIFF
--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -68,7 +68,7 @@
         engine_internal_address: "{{ engine_api_host }}"
         engine_language: "{{ engine_language }}"
         engine_license: true
-        engine_password: "{{ engine_api_root_password }}"
+        engine_password: "{{ engine_api_root_password|string }}"
       status_code: 201
 
   - name: Create tenant


### PR DESCRIPTION
reason: some people set password with only digit, which is really bad but since we don't have a specific logic to enforce strong password, we should not block it