### PR TITLE
Allow skipping Consul installation

### DIFF
--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Install Consul
   include_role:
     name: wazo-consul
+  when: wazo_consul_install
 
 # need to run after wazo_consul to have wazo_consul_token registered
 - name: Set default values

--- a/roles/wazo-vars/defaults/main.yml
+++ b/roles/wazo-vars/defaults/main.yml
@@ -53,6 +53,7 @@ sbc_dispatcher_list: "1 sip:localhost:5060 16 10"
 sbc_redis_dialog: 1
 sbc_dburl_dialog: redis://localhost:6379/3
 
+wazo_consul_install: true
 wazo_consul_host: localhost
 wazo_consul_scheme: http
 wazo_consul_port_http: 8500


### PR DESCRIPTION
Consul is an infrastructure tool and may be installed differently than Wazo's way & version. This PR allow skipping its installation.