### PR TITLE
inventories: fix invalid group characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ansible-playbook -i inventories/router c4-router.yml
 
 ## UC Engine (all in one machine)
 
-* Edit `inventories/uc-engine` and set your host in `[uc-engine-host]`
+* Edit `inventories/uc-engine` and set your host in `[uc_engine_host]`
 * Run:
 
 ```shell
@@ -80,7 +80,7 @@ ansible-playbook -i inventories/uc-engine uc-engine.yml
 * `sbc_redis_dialog`: (default: `1`) enables redis-based dialog replication
 * `sbc_dburl_dialog`: (default: `redis://localhost:6379/3`) Redis uri to store dialogs
 
-### uc-engine
+### uc_engine
 
 * `debian_upgrade_first`: (default: `true`) do we `apt-get dist-upgrade` before installing Wazo?
 
@@ -104,7 +104,7 @@ ansible-playbook -i inventories/uc-engine uc-engine.yml
 * `postgresql_superuser_password`: password for superuser `postgres`
 * `postgresql_listen_addresses`: (default: `127.0.0.1`)
 
-### engine-api
+### engine_api
 
 * `engine_api_host`: (default: `localhost`) where other services should contact the engine API
 * `engine_api_port`: (default: `443`) TCP port for HTTPS API

--- a/engine-api-init.yml
+++ b/engine-api-init.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: engine-api
+- hosts: engine_api
   become: yes
   roles:
     - engine-api-init

--- a/inventories/distributed
+++ b/inventories/distributed
@@ -6,9 +6,9 @@ asterisk-ansible
 [database]
 postgresql-ansible
 
-[edge-proxy]
+[edge_proxy]
 edge-proxy-ansible
-[edge-proxy:vars]
+[edge_proxy:vars]
 kamailio_creatordb_host = edge-proxy-ansible
 kamailio_db_host = postgresql-ansible
 kamailio_db_port = 5432
@@ -25,10 +25,10 @@ kamailio_public_ip = 198.51.100.1
 class5_wazo_servers = ["192.0.2.13"]
 rtp_engine_servers = ["udp:192.0.2.10:2223"]
 
-[engine-api]
+[engine_api]
 engine-api-ansible
 
-[reverse-proxy]
+[reverse_proxy]
 reverse-proxy-ansible
 
 [router]
@@ -62,10 +62,10 @@ rtp_engine_servers = ["udp:192.0.2.10:2223"]
 [distributed:children]
 b2bua
 database
-edge-proxy
-engine-api
+edge_proxy
+engine_api
 nestbox
-reverse-proxy
+reverse_proxy
 router
 rtpengine
 sbc
@@ -109,7 +109,7 @@ sbc_port_kamailio_http = 8888
 mirror.wazo.io
 [repo_client_cert:children]
 b2bua
-edge-proxy
+edge_proxy
 nestbox
 rtpengine
 sbc

--- a/inventories/uc-engine
+++ b/inventories/uc-engine
@@ -1,30 +1,30 @@
 # -*- conf -*-
-# You only have to change [uc-engine-host] and set variables according
+# You only have to change [uc_engine_host] and set variables according
 # to your needs (e.g. remove localhost line and add the IP on which
 # wazo-platform will be installed)
 
-[uc-engine-host]
+[uc_engine_host]
 localhost ansible_connection=local
 
 [database:children]
-uc-engine-host
+uc_engine_host
 
-[engine-api:children]
-uc-engine-host
+[engine_api:children]
+uc_engine_host
 
 [b2bua:children]
-uc-engine-host
+uc_engine_host
 
-[uc-engine:children]
+[uc_engine:children]
 b2bua
 database
-engine-api
+engine_api
 
 # Uncomment the 2 following lines if you want to deploy wazo-ui too:
-# [uc-ui:children]
-# uc-engine-host
+# [uc_ui:children]
+# uc_engine_host
 
-[uc-engine:vars]
+[uc_engine:vars]
 # Variables are defined in ../roles/wazo-vars/defaults/main.yml
 
 # Uncomment the 2 following lines to install the stable version (default is

--- a/roles/engine-api-init/tasks/main.yml
+++ b/roles/engine-api-init/tasks/main.yml
@@ -9,7 +9,7 @@
     src: /var/www/html/index.wazo.html
     dest: /var/www/html/index.html
     state: link
-  when: groups['uc-ui'] is not defined
+  when: groups['uc_ui'] is not defined
 
 - name: Install wazo-auth-keys
   apt:

--- a/roles/validate-uc/tasks/main.yml
+++ b/roles/validate-uc/tasks/main.yml
@@ -48,7 +48,7 @@
 - block:
     - name: Get the home page
       uri:
-        url: "https://{{ groups['uc-ui'][0] }}/"
+        url: "https://{{ groups['uc_ui'][0] }}/"
         validate_certs: false
       register: home_page
 
@@ -59,7 +59,7 @@
     - name: verify redirect url
       assert:
         that:
-          - home_page.url == "https://{{ groups['uc-ui'][0] }}/login/"
+          - home_page.url == "https://{{ groups['uc_ui'][0] }}/login/"
           - home_page.redirected
 
-  when: groups['uc-ui'] is defined
+  when: groups['uc_ui'] is defined

--- a/test.yml
+++ b/test.yml
@@ -1,4 +1,4 @@
 ---
-- hosts: uc-engine-host
+- hosts: uc_engine_host
   roles:
     - role: validate-uc

--- a/uc-engine.yml
+++ b/uc-engine.yml
@@ -7,7 +7,7 @@
 - hosts:
     - database
     - b2bua
-    - engine-api
+    - engine_api
   become: yes
   roles:
     - role: debian-upgrade-first
@@ -23,14 +23,14 @@
   roles:
     - role: b2bua
 
-- hosts: engine-api
+- hosts: engine_api
   become: yes
   roles:
     - role: engine-api
     - role: engine-api-init
     - role: uc-engine
 
-- hosts: uc-ui
+- hosts: uc_ui
   become: yes
   roles:
     - role: uc-ui


### PR DESCRIPTION
Why:

* dash (-) characters are considered invalid in group names by ansible 2.9, which prints a deprecation warning.

Depends-On: https://github.com/wazo-platform/sf-jobs/pull/55