### PR TITLE
uc-engine: ensure dbus is started

### DIFF
--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -77,9 +77,9 @@
 
   - name: Enable policy for API client
     command: "wazo-auth-cli user add {{ api_client_name }} --policy api-client-policy"
-  when: engine_api_configure_wizard == "true"
 
   - name: Ensure dbus is started
     service:
       name: dbus
       state: started
+  when: engine_api_configure_wizard == "true"

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -78,3 +78,8 @@
   - name: Enable policy for API client
     command: "wazo-auth-cli user add {{ api_client_name }} --policy api-client-policy"
   when: engine_api_configure_wizard == "true"
+
+  - name: Ensure dbus is started
+    service:
+      name: dbus
+      state: started


### PR DESCRIPTION
Why:

* wazo-service needs dbus to function (via systemctl)