### PR TITLE
Pull request for WAZO-1991-different-debian-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ For a new Wazo engine installation, there are two distribution to consider:
   install an all in one setup.
 * `wazo_extra_repository`: debian repository to add to the installation.
 * `wazo_extra_repository_filename`: (default `wazo-extra`) filename for the extra repository configuration.
+* `wazo_extra_repository_key_url`: URL for adding an extra signature key for package verification
+* `wazo_extra_repository_key_id`: ID of an extra signature key for package verification
+* `debian_repo_wazo__custom_repo`: debian repository to replace the default Wazo repository
+* `debian_repo_wazo__custom_repo_filename`: filename for the debian repository to replace the default Wazo repository
+* `debian_repo_wazo__custom_repo_upgrade`: debian repository to replace the default Wazo repository for later upgrades
+* `debian_repo_wazo__custom_repo_upgrade_filename`: filename for the debian repository to replace the default Wazo repository for later upgrades
+
 
 ### runtime
 

--- a/README.md
+++ b/README.md
@@ -172,10 +172,6 @@ For a new Wazo engine installation, there are two distribution to consider:
   set up at the end for later upgrades.
 * `wazo_meta_package`: (default `wazo-platform`) meta package to
   install an all in one setup.
-* `wazo_extra_repository`: debian repository to add to the installation.
-* `wazo_extra_repository_filename`: (default `wazo-extra`) filename for the extra repository configuration.
-* `wazo_extra_repository_key_url`: URL for adding an extra signature key for package verification
-* `wazo_extra_repository_key_id`: ID of an extra signature key for package verification
 * `debian_repo_wazo__key_url`: URL for the package verification key
 * `debian_repo_wazo__key_id`: ID of the package verification key
 * `debian_repo_wazo__custom_repo`: debian repository to replace the default Wazo repository

--- a/README.md
+++ b/README.md
@@ -176,9 +176,7 @@ For a new Wazo engine installation, there are two distribution to consider:
 * `debian_repo_wazo__key_id`: ID of the package verification key
 * `debian_repo_wazo__custom_repo`: debian repository to replace the default Wazo repository
 * `debian_repo_wazo__custom_repo_filename`: filename for the debian repository to replace the default Wazo repository
-* `debian_repo_wazo__custom_repo_upgrade`: debian repository to replace the default Wazo repository for later upgrades
-* `debian_repo_wazo__custom_repo_upgrade_filename`: filename for the debian repository to replace the default Wazo repository for later upgrades
-
+* `debian_repo_wazo__custom_repo_upgrade`: debian repository to replace the custom repository for later upgrades
 
 ### runtime
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ For a new Wazo engine installation, there are two distribution to consider:
 * `wazo_extra_repository_filename`: (default `wazo-extra`) filename for the extra repository configuration.
 * `wazo_extra_repository_key_url`: URL for adding an extra signature key for package verification
 * `wazo_extra_repository_key_id`: ID of an extra signature key for package verification
+* `debian_repo_wazo__key_url`: URL for the package verification key
+* `debian_repo_wazo__key_id`: ID of the package verification key
 * `debian_repo_wazo__custom_repo`: debian repository to replace the default Wazo repository
 * `debian_repo_wazo__custom_repo_filename`: filename for the debian repository to replace the default Wazo repository
 * `debian_repo_wazo__custom_repo_upgrade`: debian repository to replace the default Wazo repository for later upgrades

--- a/roles/debian-repo-wazo/tasks/main.yml
+++ b/roles/debian-repo-wazo/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
-- name: Install APT python bindings and GPG
+- name: Install APT python bindings, GPG and CA certificates
   apt:
     name:
       - python-apt
       - gpg
+      - ca-certificates  # for HTTPS Debian repo
     state: present
 
 - name: Add Wazo distribution key

--- a/roles/debian-repo-wazo/tasks/main.yml
+++ b/roles/debian-repo-wazo/tasks/main.yml
@@ -54,18 +54,3 @@
     filename: "{{ debian_repo_wazo__custom_repo_filename }}"
     update_cache: yes
   when: debian_repo_wazo__custom_repo is defined
-
-- name: Add extra distribution key
-  apt_key:
-    url: "{{ debian_repo_wazo__extra_key_url }}"
-    id: "{{ debian_repo_wazo__extra_key_id }}"
-    state: present
-  when: debian_repo_wazo__extra_key_url is defined
-
-- name: Add extra repository
-  apt_repository:
-    repo: "{{ wazo_extra_repository }}"
-    state: present
-    filename: "{{ wazo_extra_repository_filename }}"
-    update_cache: yes
-  when: wazo_extra_repository is defined

--- a/roles/debian-repo-wazo/tasks/main.yml
+++ b/roles/debian-repo-wazo/tasks/main.yml
@@ -12,33 +12,54 @@
     id: 2769B67EDBFF423F6874D7663F1BF7FC527FBC6A
     state: present
 
-- name: Gather packages facts
-  package_facts:
-    manager: apt
+- name: Bootstrap with wazo-dist
+  block:
 
-- name: Add bootstrap Wazo repository
+  - name: Gather packages facts
+    package_facts:
+      manager: apt
+
+  - name: Add bootstrap Wazo repository
+    apt_repository:
+      repo: deb http://mirror.wazo.community/{{ 'debian' if wazo_debian_repo == 'main' else wazo_debian_repo }} {{ wazo_distribution }} main
+      state: present
+      filename: wazo-install
+      update_cache: yes
+    when: '"wazo-dist" not in ansible_facts.packages'
+
+  - name: Install wazo-dist
+    apt:
+      name: wazo-dist
+      state: present
+
+  - name: Add persistent Wazo repository # noqa 301
+    command: wazo-dist --{{ wazo_debian_repo }}-repo {{ wazo_distribution }}
+
+  - name: Remove bootstrap Wazo repository
+    apt_repository:
+      repo: deb http://mirror.wazo.community/{{ 'debian' if wazo_debian_repo == 'main' else wazo_debian_repo }} {{ wazo_distribution }} main
+      state: absent
+      filename: wazo-install
+      update_cache: yes
+    when: '"wazo-dist" not in ansible_facts.packages'
+
+  # end block
+  when: debian_repo_wazo__custom_repo is not defined
+
+- name: Add custom repository
   apt_repository:
-    repo: deb http://mirror.wazo.community/{{ 'debian' if wazo_debian_repo == 'main' else wazo_debian_repo }} {{ wazo_distribution }} main
+    repo: "{{ debian_repo_wazo__custom_repo }}"
     state: present
-    filename: wazo-install
+    filename: "{{ debian_repo_wazo__custom_repo_filename }}"
     update_cache: yes
-  when: '"wazo-dist" not in ansible_facts.packages'
+  when: debian_repo_wazo__custom_repo is defined
 
-- name: Install wazo-dist
-  apt:
-    name: wazo-dist
+- name: Add extra distribution key
+  apt_key:
+    url: "{{ debian_repo_wazo__extra_key_url }}"
+    id: "{{ debian_repo_wazo__extra_key_id }}"
     state: present
-
-- name: Add persistent Wazo repository # noqa 301
-  command: wazo-dist --{{ wazo_debian_repo }}-repo {{ wazo_distribution }}
-
-- name: Remove bootstrap Wazo repository
-  apt_repository:
-    repo: deb http://mirror.wazo.community/{{ 'debian' if wazo_debian_repo == 'main' else wazo_debian_repo }} {{ wazo_distribution }} main
-    state: absent
-    filename: wazo-install
-    update_cache: yes
-  when: '"wazo-dist" not in ansible_facts.packages'
+  when: debian_repo_wazo__extra_key_url is defined
 
 - name: Add extra repository
   apt_repository:

--- a/roles/debian-repo-wazo/tasks/main.yml
+++ b/roles/debian-repo-wazo/tasks/main.yml
@@ -8,8 +8,8 @@
 
 - name: Add Wazo distribution key
   apt_key:
-    url: http://mirror.wazo.community/wazo_current.key
-    id: 2769B67EDBFF423F6874D7663F1BF7FC527FBC6A
+    url: "{{ debian_repo_wazo__key_url }}"
+    id: "{{ debian_repo_wazo__key_id }}"
     state: present
 
 - name: Bootstrap with wazo-dist

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -49,6 +49,26 @@
 
 - name: Change Wazo distribution for later upgrades # noqa 301
   command: wazo-dist --{{ wazo_debian_repo_upgrade }}-repo {{ wazo_distribution_upgrade }}
+  when: debian_repo_wazo__custom_repo is not defined
+
+- name: Remove custom repository used for installation
+  apt_repository:
+    repo: "{{ debian_repo_wazo__custom_repo }}"
+    state: absent
+    filename: "{{ debian_repo_wazo__custom_repo_filename }}"
+    update_cache: yes
+  when: |
+    debian_repo_wazo__custom_repo_filename is defined
+    and debian_repo_wazo__custom_repo_upgrade_filename is defined
+    and debian_repo_wazo__custom_repo_filename == debian_repo_wazo__custom_repo_upgrade_filename
+
+- name: Add custom repository for later upgrades
+  apt_repository:
+    repo: "{{ debian_repo_wazo__custom_repo_upgrade }}"
+    state: present
+    filename: "{{ debian_repo_wazo__custom_repo_upgrade_filename }}"
+    update_cache: yes
+  when: debian_repo_wazo__custom_repo_upgrade is defined
 
 - name: Ensure dbus is started
   service:

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -57,16 +57,13 @@
     state: absent
     filename: "{{ debian_repo_wazo__custom_repo_filename }}"
     update_cache: yes
-  when: |
-    debian_repo_wazo__custom_repo_filename is defined
-    and debian_repo_wazo__custom_repo_upgrade_filename is defined
-    and debian_repo_wazo__custom_repo_filename == debian_repo_wazo__custom_repo_upgrade_filename
+  when: debian_repo_wazo__custom_repo_upgrade is defined
 
 - name: Add custom repository for later upgrades
   apt_repository:
     repo: "{{ debian_repo_wazo__custom_repo_upgrade }}"
     state: present
-    filename: "{{ debian_repo_wazo__custom_repo_upgrade_filename }}"
+    filename: "{{ debian_repo_wazo__custom_repo_filename }}"
     update_cache: yes
   when: debian_repo_wazo__custom_repo_upgrade is defined
 

--- a/roles/wazo-vars/defaults/main.yml
+++ b/roles/wazo-vars/defaults/main.yml
@@ -8,6 +8,9 @@ wazo_meta_package: wazo-platform
 # wazo_extra_repository: deb http://mirror.wazo.community/extra/ extra-buster main
 wazo_extra_repository_filename: wazo-extra
 
+debian_repo_wazo__key_url: http://mirror.wazo.community/wazo_current.key
+debian_repo_wazo__key_id: 2769B67EDBFF423F6874D7663F1BF7FC527FBC6A
+
 engine_api_host: localhost
 engine_api_port: 443
 engine_api_tracing: false

--- a/roles/wazo-vars/defaults/main.yml
+++ b/roles/wazo-vars/defaults/main.yml
@@ -5,8 +5,6 @@ wazo_debian_repo_upgrade: main
 wazo_distribution: wazo-dev-buster
 wazo_distribution_upgrade: wazo-dev-buster
 wazo_meta_package: wazo-platform
-# wazo_extra_repository: deb http://mirror.wazo.community/extra/ extra-buster main
-wazo_extra_repository_filename: wazo-extra
 
 debian_repo_wazo__key_url: http://mirror.wazo.community/wazo_current.key
 debian_repo_wazo__key_id: 2769B67EDBFF423F6874D7663F1BF7FC527FBC6A


### PR DESCRIPTION
This PR allows installing Wazo Platform with a configurable additional Debian repository. This additional repository may also be configured to be used during future upgrades.