### PR TITLE
set default python interpreter to python3

### DIFF
--- a/inventories/uc-engine
+++ b/inventories/uc-engine
@@ -3,6 +3,9 @@
 # to your needs (e.g. remove localhost line and add the IP on which
 # wazo-platform will be installed)
 
+[all:vars]
+ansible_python_interpreter = /usr/bin/python3
+
 [uc_engine_host]
 localhost ansible_connection=local
 


### PR DESCRIPTION
reason: by default it use /usr/bin/python which refer to python 2 and
can be not installed on fresh install that have only python3