### PR TITLE
remove install gpg key at the end of install

### DIFF
--- a/roles/debian-repo-wazo/tasks/main.yml
+++ b/roles/debian-repo-wazo/tasks/main.yml
@@ -12,6 +12,7 @@
     url: "{{ debian_repo_wazo__key_url }}"
     id: "{{ debian_repo_wazo__key_id }}"
     state: present
+    keyring: /etc/apt/trusted.gpg.d/wazo-keyring-installation.gpg
 
 - name: Bootstrap with wazo-dist
   block:

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -63,6 +63,12 @@
   command: wazo-dist --{{ wazo_debian_repo_upgrade }}-repo {{ wazo_distribution_upgrade }}
   when: debian_repo_wazo__custom_repo is not defined
 
+- name: Remove custom gpg key used for installation
+  apt_key:
+    id: "{{ debian_repo_wazo__key_id }}"
+    state: absent
+    keyring: /etc/apt/trusted.gpg.d/wazo-keyring-installation.gpg
+
 - name: Remove custom repository used for installation
   apt_repository:
     repo: "{{ debian_repo_wazo__custom_repo }}"

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -63,11 +63,19 @@
   command: wazo-dist --{{ wazo_debian_repo_upgrade }}-repo {{ wazo_distribution_upgrade }}
   when: debian_repo_wazo__custom_repo is not defined
 
-- name: Remove custom gpg key used for installation
+- name: Remove custom GPG key used for installation
   apt_key:
     id: "{{ debian_repo_wazo__key_id }}"
     state: absent
     keyring: /etc/apt/trusted.gpg.d/wazo-keyring-installation.gpg
+
+- name: Remove empty keyring file used for installation
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /etc/apt/trusted.gpg.d/wazo-keyring-installation.gpg
+    - /etc/apt/trusted.gpg.d/wazo-keyring-installation.gpg~
 
 - name: Remove custom repository used for installation
   apt_repository:


### PR DESCRIPTION
why: because wazo-keyring package will handle future migration