### PR TITLE
wazo-message-bus: don't become unprivileged user

### DIFF
--- a/roles/wazo-message-bus/tasks/main.yml
+++ b/roles/wazo-message-bus/tasks/main.yml
@@ -11,9 +11,7 @@
     state: present
 
 - name: Enable Consul discovery in RabbitMQ
-  command: "rabbitmq-plugins --offline enable rabbitmq_peer_discovery_consul"
-  become: true
-  become_user: rabbitmq
+  command: "sudo -u rabbitmq rabbitmq-plugins --offline enable rabbitmq_peer_discovery_consul"
   when: runtime
 
 - name: Create /etc/rabbitmq/rabbitmq.conf


### PR DESCRIPTION
Why:

* This prevents the role from being used with a non-root user
  * Use case: provisioning a machine with local ansible recipe to a
    hosting service that does not allow SSH access to user root
* This is a known issue with Ansible:
https://docs.ansible.com/ansible/latest/user_guide/become.html#sts=Risks
of becoming an unprivileged user