### PR TITLE
remove unused asterisk 5040 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ ansible-playbook -i inventories/uc-engine uc-engine.yml
 * `b2bua_listen_address`: (default: `127.0.0.1`)
 * `b2bua_port_ami`: (default: `5038`) TCP port for AMI
 * `b2bua_port_http`: (default: `5039`) TCP port for HTTP interfaces
-* `b2bua_port_https`: (default: `5040`) TCP port for HTTPS interfaces
 * `b2bua_port_sysconfd`: (default: `8668`) TCP port for wazo-sysconfd HTTP interface
 * `b2bua_https_cert`: custom certificate filename for HTTPS
 * `b2bua_https_private_key`: custom private key filename for HTTPS

--- a/inventories/distributed
+++ b/inventories/distributed
@@ -72,7 +72,6 @@ sbc
 b2bua_host = asterisk-ansible
 b2bua_port_ami = 5038
 b2bua_port_http = 5039
-b2bua_port_https = 5040
 b2bua_port_sysconfd = 8668
 b2bua_ami_permit_client_address = 0.0.0.0
 b2bua_ami_permit_client_mask = 0.0.0.0

--- a/roles/b2bua/tasks/main.yml
+++ b/roles/b2bua/tasks/main.yml
@@ -94,7 +94,6 @@
   when:
     - b2bua_listen_address is defined
     - b2bua_port_http is defined
-    - b2bua_port_https is defined
 
 - name: Install wazo-confgend-client
   apt:

--- a/roles/b2bua/templates/asterisk-http.conf.j2
+++ b/roles/b2bua/templates/asterisk-http.conf.j2
@@ -1,4 +1,3 @@
 [general](+)
 bindaddr={{ b2bua_listen_address }}
 bindport={{ b2bua_port_http }}
-tlsbindaddr={{ b2bua_listen_address }}:{{ b2bua_port_https }}

--- a/roles/engine-api/tasks/main.yml
+++ b/roles/engine-api/tasks/main.yml
@@ -66,7 +66,7 @@
     - ami_username is defined
     - b2bua_host is defined
     - b2bua_port_ami is defined
-    - b2bua_port_https is defined
+    - b2bua_port_http is defined
 
 - name: Install wazo-amid
   apt:

--- a/roles/engine-api/templates/wazo-amid.yml.j2
+++ b/roles/engine-api/templates/wazo-amid.yml.j2
@@ -6,7 +6,6 @@ ami:
 
 ajam:
   host: {{ b2bua_host }}
-  port: {{ b2bua_port_https }}
+  port: {{ b2bua_port_http }}
   username: {{ ami_username }}
   password: {{ ami_password }}
-  verify_certificate: false


### PR DESCRIPTION
Depends-on: WAZO-2174-remove-ajam-ssl

why: everything use 5039 now