### PR TITLE
do not install consul by default

### DIFF
--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -15,25 +15,6 @@
     purge: yes
     state: absent
 
-- name: Install Consul
-  include_role:
-    name: wazo-consul
-
-- name: Ensure wazo-auth has been registered to consul
-  service:
-    name: wazo-auth
-    state: restarted
-
-- name: Ensure wazo-calld has been registered to consul
-  service:
-    name: wazo-calld
-    state: restarted
-
-- name: Ensure wazo-confd has been registered to consul
-  service:
-    name: wazo-confd
-    state: restarted
-
 # need to run after wazo_consul to have wazo_consul_token registered
 - name: Set default values
   include_role:

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -15,11 +15,6 @@
     purge: yes
     state: absent
 
-# need to run after wazo_consul to have wazo_consul_token registered
-- name: Set default values
-  include_role:
-    name: wazo-default
-
 - name: "Install {{ wazo_meta_package }}"
   apt:
     name: "{{ wazo_meta_package }}"

--- a/roles/validate-uc/tasks/main.yml
+++ b/roles/validate-uc/tasks/main.yml
@@ -2,18 +2,6 @@
   shell: "vers={{ wazo_distribution }}; echo ${vers##*-} $(cat /usr/share/wazo/WAZO-VERSION); test ${vers##*-} = $(cat /usr/share/wazo/WAZO-VERSION)"
   when: wazo_debian_repo == "archive"
 
-- name: Check that wazo-auth is listed in Consul services # noqa 301
-  shell: |
-    set -o pipefail
-    consul catalog services|grep wazo-auth
-  args:
-    executable: /bin/bash
-  register: result
-  until: result.rc == 0
-  retries: 6
-  delay: 10
-  when: wazo_consul_host is defined
-
 - name: Get token
   uri:
     url: "https://{{ engine_api_host }}:{{ engine_api_port }}{{ engine_auth_path }}/token"

--- a/roles/validate-uc/tasks/main.yml
+++ b/roles/validate-uc/tasks/main.yml
@@ -12,6 +12,7 @@
   until: result.rc == 0
   retries: 6
   delay: 10
+  when: wazo_consul_host is defined
 
 - name: Get token
   uri:

--- a/roles/wazo-default/tasks/main.yml
+++ b/roles/wazo-default/tasks/main.yml
@@ -3,29 +3,31 @@
   file:
     path: /etc/wazo-platform
     state: directory
+  when: wazo_consul_host is defined
 
 - name: Configure Consul access (copy)
   copy:
     src: files/consul
     dest: /etc/wazo-platform/consul
-  when: not runtime
+  when: not runtime and wazo_consul_host is defined
 
 - name: Configure Consul access (template)
   template:
     src: templates/consul.j2
     dest: /etc/wazo-platform/consul
-  when: runtime
+  when: runtime and wazo_consul_host is defined
 
 - name: Creates directory /var/lib/consul
   file:
     path: /var/lib/consul
     state: directory
+  when: wazo_consul_host is defined
 
 - name: Configure Consul access config
   template:
     src: templates/default_xivo_consul_config.yml.j2
     dest: /var/lib/consul/default_xivo_consul_config.yml
-  when: runtime
+  when: runtime and wazo_consul_host is defined
 
 # be sure to call the wazo_consul role before to have
 # wazo_consul_token registered
@@ -33,4 +35,4 @@
   template:
     src: templates/default_xivo_consul_token.yml.j2
     dest: /var/lib/consul/default_xivo_consul_token.yml
-  when: runtime and wazo_consul_token is defined
+  when: runtime and and wazo_consul_host is defined and wazo_consul_token is defined

--- a/roles/wazo-default/tasks/main.yml
+++ b/roles/wazo-default/tasks/main.yml
@@ -3,31 +3,29 @@
   file:
     path: /etc/wazo-platform
     state: directory
-  when: wazo_consul_host is defined
 
 - name: Configure Consul access (copy)
   copy:
     src: files/consul
     dest: /etc/wazo-platform/consul
-  when: not runtime and wazo_consul_host is defined
+  when: not runtime
 
 - name: Configure Consul access (template)
   template:
     src: templates/consul.j2
     dest: /etc/wazo-platform/consul
-  when: runtime and wazo_consul_host is defined
+  when: runtime
 
 - name: Creates directory /var/lib/consul
   file:
     path: /var/lib/consul
     state: directory
-  when: wazo_consul_host is defined
 
 - name: Configure Consul access config
   template:
     src: templates/default_xivo_consul_config.yml.j2
     dest: /var/lib/consul/default_xivo_consul_config.yml
-  when: runtime and wazo_consul_host is defined
+  when: runtime
 
 # be sure to call the wazo_consul role before to have
 # wazo_consul_token registered
@@ -35,4 +33,4 @@
   template:
     src: templates/default_xivo_consul_token.yml.j2
     dest: /var/lib/consul/default_xivo_consul_token.yml
-  when: runtime and and wazo_consul_host is defined and wazo_consul_token is defined
+  when: runtime and wazo_consul_token is defined

--- a/roles/wazo-message-bus/tasks/main.yml
+++ b/roles/wazo-message-bus/tasks/main.yml
@@ -10,15 +10,10 @@
     name: rabbitmq-server
     state: present
 
+# Used by role2docker project
 - name: Enable Consul discovery in RabbitMQ
   command: "sudo -u rabbitmq rabbitmq-plugins --offline enable rabbitmq_peer_discovery_consul"
-  when: runtime and wazo_consul_host is defined
-
-- name: Create /etc/rabbitmq/rabbitmq.conf
-  template:
-    src: templates/rabbitmq.conf.j2
-    dest: /etc/rabbitmq/rabbitmq.conf
-  when: runtime and wazo_consul_host is defined
+  when: runtime
 
 - name: Ensure RabbitMQ is restarted
   service:

--- a/roles/wazo-message-bus/tasks/main.yml
+++ b/roles/wazo-message-bus/tasks/main.yml
@@ -12,13 +12,13 @@
 
 - name: Enable Consul discovery in RabbitMQ
   command: "sudo -u rabbitmq rabbitmq-plugins --offline enable rabbitmq_peer_discovery_consul"
-  when: runtime
+  when: runtime and wazo_consul_host is defined
 
 - name: Create /etc/rabbitmq/rabbitmq.conf
   template:
     src: templates/rabbitmq.conf.j2
     dest: /etc/rabbitmq/rabbitmq.conf
-  when: runtime
+  when: runtime and wazo_consul_host is defined
 
 - name: Ensure RabbitMQ is restarted
   service:

--- a/roles/wazo-message-bus/templates/rabbitmq.conf.j2
+++ b/roles/wazo-message-bus/templates/rabbitmq.conf.j2
@@ -1,5 +1,0 @@
-cluster_formation.peer_discovery_backend = rabbit_peer_discovery_consul
-
-cluster_formation.consul.host = {{ wazo_consul_host }}
-cluster_formation.consul.port = {{ wazo_consul_port_http if wazo_consul_scheme == 'http' else wazo_consul_port_https }}
-cluster_formation.consul.scheme = {{ wazo_consul_scheme }}


### PR DESCRIPTION
why: consul is not used
But keep roles being able to be configured to use an external consul
server

Depends-on: https://github.com/wazo-platform/wazo-setupd/pull/56
Depends-on: https://github.com/wazo-platform/wazo-backup/pull/13
Depends-on: https://github.com/wazo-platform/wazo-webhookd/pull/149
Depends-on: https://github.com/wazo-platform/wazo-dird/pull/148
Depends-on: https://github.com/wazo-platform/wazo-confd/pull/334
Depends-on: https://github.com/wazo-platform/wazo-platform/pull/68
Depends-on: https://github.com/wazo-platform/wazo-auth/pull/258
Depends-on: https://github.com/wazo-platform/wazo-upgrade/pull/61
Depends-on: https://github.com/wazo-platform/wazo-chatd/pull/108
Depends-on: https://github.com/wazo-platform/xivo-monitoring/pull/16
Depends-on: https://github.com/wazo-platform/wazo-calld/pull/245
Depends-on: https://github.com/wazo-platform/wazo-agentd/pull/80
Depends-on: https://github.com/wazo-platform/wazo-plugind/pull/58
