### PR TITLE
Removed obsolete twistd invocations

### DIFF
--- a/roles/engine-api-init/tasks/main.yml
+++ b/roles/engine-api-init/tasks/main.yml
@@ -57,9 +57,6 @@
 - name: Initialize main database # noqa 301
   command: dpkg-reconfigure xivo-manage-db --frontend noninteractive
 
-- name: Fix Twisted dropin.cache # noqa 301
-  command: twistd3 --help-reactors
-
 - name: Start Wazo services
   service:
     name: "{{ item }}"

--- a/roles/wazo-auth/docker/init
+++ b/roles/wazo-auth/docker/init
@@ -20,7 +20,6 @@ if [ ! -r /etc/xivo-manage-db.cfg ]; then
     echo PURGE | debconf-communicate xivo-manage-db
     debconf-set-selections /etc/xivo-manage-db.cfg
     dpkg-reconfigure xivo-manage-db --frontend noninteractive
-    twistd --help-reactors
 fi
 
 # Consul setup


### PR DESCRIPTION
https://wazo-dev.atlassian.net/browse/WAZO-2946

Original issue motivating these fixes occurred and were only reported in python 2 deployments. The issue couldn't be replicated in latests python 3 deployments of twisted-based services(wazo-confgend, wazo-provd).
Since those invocations of twistd add operational complexity(coupling with an implementation details of some component implementations, requiring occasional maintenance effort), and use of twisted is likely to disappear at some point in the future, it seems reasonable to remove those invocations of twistd until the issue proves to be reoccurring in new python 3-based releases.