### PR TITLE
zuul: use explicit bullseye job for experimental pipeline

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -11,5 +11,4 @@
             nodeset: pod-debian-11
     experimental:
       jobs:
-        - wazo-acceptance:
-            nodeset: vm-debian-11-m1s
+        - wazo-acceptance-bullseye


### PR DESCRIPTION
why: we want to remove all buster jobs, and "wazo-acceptance" is one of
them

Note: Current master branch is broken and "check experimental" cannot success.
Please trigger `check experimental` when everything will be fixed on master