### PR TITLE
WAZO-4217-remove-bullseye-backports

### DIFF
--- a/roles/debian-repo-wazo/tasks/main.yml
+++ b/roles/debian-repo-wazo/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: Delete vanished bullseye-backports repository
-  ansible.builtin.apt_repository:
-    repo: deb http://deb.debian.org/debian bullseye-backports main
-    state: absent
-    update_cache: false
-
-- name: Delete vanished bullseye-backports source repository
-  ansible.builtin.apt_repository:
-    repo: deb-src http://deb.debian.org/debian bullseye-backports main
-    state: absent
-    update_cache: false
-
 - name: Install APT python bindings, GPG and CA certificates
   ansible.builtin.apt:
     name:

--- a/roles/debian-repo-wazo/tasks/main.yml
+++ b/roles/debian-repo-wazo/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Delete vanished bullseye-backports repository
+  ansible.builtin.apt_repository:
+    repo: deb http://deb.debian.org/debian bullseye-backports main
+    state: absent
+    update_cache: false
+
+- name: Delete vanished bullseye-backports source repository
+  ansible.builtin.apt_repository:
+    repo: deb-src http://deb.debian.org/debian bullseye-backports main
+    state: absent
+    update_cache: false
+
 - name: Install APT python bindings, GPG and CA certificates
   ansible.builtin.apt:
     name:

--- a/roles/debian-upgrade-first/tasks/main.yml
+++ b/roles/debian-upgrade-first/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Delete vanished bullseye-backports repository
+  ansible.builtin.apt_repository:
+    repo: deb http://deb.debian.org/debian bullseye-backports main
+    state: absent
+    update_cache: false
+
+- name: Delete vanished bullseye-backports source repository
+  ansible.builtin.apt_repository:
+    repo: deb-src http://deb.debian.org/debian bullseye-backports main
+    state: absent
+    update_cache: false
+
 - name: Upgrade Debian before anything
   ansible.builtin.apt:
     update_cache: true


### PR DESCRIPTION
why: those repository are not available anymore and most new debian
installation provide them by default
