### PR TITLE
WAZO-4338-upgrade-bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites for all recipes
 
-* Enough machines running with Debian Bullseye vanilla
+* Enough machines running with Debian Bookworm vanilla
 * You can become root on the target machines (See https://docs.ansible.com/ansible/latest/user_guide/become.html)
 * Ansible 2.10.7: `pip install ansible==2.10.7`
 
@@ -83,9 +83,9 @@ Wazo has two difference Debian repositories: the `main` and `archive`
 repositories. Each repository contains multiple distributions, themselves
 containing multiple packages, in a certain version:
 
-  * The `main` repository contains the "rolling" distributions: `phoenix-bullseye`,
-    `pelican-bullseye`, `wazo-dev-bullseye`, etc. Packages in those distributions
-    are updated at each release, except `wazo-dev-bullseye` which is constantly
+  * The `main` repository contains the "rolling" distributions: `phoenix-bookworm`,
+    `pelican-bookworm`, `wazo-dev-bookworm`, etc. Packages in those distributions
+    are updated at each release, except `wazo-dev-bookworm` which is constantly
     updated.
   * The `archive` repository contains the "frozen" distributions: `wazo-19.10`,
     `wazo-19.11`, etc. Packages in those distribution do not change (except for
@@ -103,12 +103,12 @@ For a new Wazo engine installation, there are two distributions to consider:
 
 * `wazo_debian_repo`: (default: `main`) wazo repository from where packages are
   installed. Valid values: `main` and `archive`
-* `wazo_distribution`: (default: `wazo-dev-bullseye`) wazo distribution from
+* `wazo_distribution`: (default: `wazo-dev-bookworm`) wazo distribution from
   where packages are installed
 * `wazo_debian_repo_upgrade`: (default: `main`) wazo repository for later
   upgrades. This repo is not used during installation, only set up at the end
   for later upgrades. Valid values: `main` and `archive`
-* `wazo_distribution_upgrade`: (default: `wazo-dev-bullseye`) wazo distribution
+* `wazo_distribution_upgrade`: (default: `wazo-dev-bookworm`) wazo distribution
   for later upgrades. This distribution is not used during installation, only
   set up at the end for later upgrades.
 * `wazo_meta_package`: (default `wazo-platform`) meta package to

--- a/inventories/uc-engine
+++ b/inventories/uc-engine
@@ -32,8 +32,8 @@ engine_api
 
 # Uncomment the 2 following lines to install the stable version (default is
 # development version)
-# wazo_distribution = wazo-dev-bullseye
-# wazo_distribution_upgrade = wazo-dev-bullseye
+# wazo_distribution = wazo-dev-bookworm
+# wazo_distribution_upgrade = wazo-dev-bookworm
 
 # PostgreSQL settings
 # postgresql_port = 5432

--- a/requirements-postgresql.yml
+++ b/requirements-postgresql.yml
@@ -1,2 +1,2 @@
 - src: geerlingguy.postgresql
-  version: 3.3.1
+  version: 4.0.1

--- a/roles/b2bua/meta/main.yml
+++ b/roles/b2bua/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/debian-repo-wazo/meta/main.yml
+++ b/roles/debian-repo-wazo/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/debian-upgrade-first/meta/main.yml
+++ b/roles/debian-upgrade-first/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/debian-upgrade-first/tasks/main.yml
+++ b/roles/debian-upgrade-first/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: Delete vanished bullseye-backports repository
-  ansible.builtin.apt_repository:
-    repo: deb http://deb.debian.org/debian bullseye-backports main
-    state: absent
-    update_cache: false
-
-- name: Delete vanished bullseye-backports source repository
-  ansible.builtin.apt_repository:
-    repo: deb-src http://deb.debian.org/debian bullseye-backports main
-    state: absent
-    update_cache: false
-
 - name: Upgrade Debian before anything
   ansible.builtin.apt:
     update_cache: true

--- a/roles/engine-api-init/meta/main.yml
+++ b/roles/engine-api-init/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/engine-api/meta/main.yml
+++ b/roles/engine-api/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/preflight-checks/meta/main.yml
+++ b/roles/preflight-checks/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Preflight checks
   when: preflight_checks_done is undefined
   block:
-    - name: Assert Debian Bullseye
+    - name: Assert Debian Bookworm
       ansible.builtin.assert:
-        that: ansible_distribution == 'Debian' and ansible_distribution_major_version == '11'
+        that: ansible_distribution == 'Debian' and ansible_distribution_major_version == '12'
 
     - name: Validate database names
       ansible.builtin.assert:

--- a/roles/uc-engine/meta/main.yml
+++ b/roles/uc-engine/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/uc-engine/tasks/main.yml
+++ b/roles/uc-engine/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
-- name: Install the ntp and postfix daemons
-  # Some machines have chrony installed
+- name: Install the ntpsec and postfix daemons
+  # Default bookworm installation has systemd-timesyncd installed
+  # It also solve issue when chrony or openntpd is installed
   ansible.builtin.apt:
     name:
-      - ntp
+      - ntpsec
       - postfix
     state: present
 

--- a/roles/uc-ui/meta/main.yml
+++ b/roles/uc-ui/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/validate-uc-ui/meta/main.yml
+++ b/roles/validate-uc-ui/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/validate-uc/meta/main.yml
+++ b/roles/validate-uc/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/wazo-auth/meta/main.yml
+++ b/roles/wazo-auth/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/wazo-certs/meta/main.yml
+++ b/roles/wazo-certs/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/wazo-db/meta/main.yml
+++ b/roles/wazo-db/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/wazo-db/tasks/main.yml
+++ b/roles/wazo-db/tasks/main.yml
@@ -20,6 +20,8 @@
     postgresql_global_config_options:
       - option: port
         value: "{{ postgresql_port | default(5432) }}"
+      - option: log_directory  # See https://github.com/geerlingguy/ansible-role-postgresql/issues/217
+        value: 'log'
     postgresql_users: []
 
 - name: Set PostgreSQL superadmin password
@@ -55,3 +57,5 @@
         value: "{{ postgresql_port | default(5432) }}"
       - option: listen_addresses
         value: "{{ postgresql_listen_addresses | default('127.0.0.1') }}"
+      - option: log_directory  # See https://github.com/geerlingguy/ansible-role-postgresql/issues/217
+        value: 'log'

--- a/roles/wazo-message-bus/meta/main.yml
+++ b/roles/wazo-message-bus/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - bullseye
-  min_ansible_version: "2.5"
+        - bookworm
+  min_ansible_version: "7.7"
 dependencies:
   - role: wazo-vars

--- a/roles/wazo-vars/defaults/main.yml
+++ b/roles/wazo-vars/defaults/main.yml
@@ -7,7 +7,7 @@ wazo_distribution_upgrade: wazo-dev-bullseye
 wazo_meta_package: wazo-platform
 
 debian_repo_wazo__key_url: https://mirror.wazo.community/wazo_current.key
-debian_repo_wazo__key_id: 012391C4B871734F505B1F3A778B8E0319121AED
+debian_repo_wazo__key_id: 07BD80E9769F598C0C8281253130D90DD87E06EF
 
 engine_api_host: localhost
 engine_api_port: 443

--- a/roles/wazo-vars/defaults/main.yml
+++ b/roles/wazo-vars/defaults/main.yml
@@ -2,8 +2,8 @@ debian_upgrade_first: true
 
 wazo_debian_repo: main
 wazo_debian_repo_upgrade: main
-wazo_distribution: wazo-dev-bullseye
-wazo_distribution_upgrade: wazo-dev-bullseye
+wazo_distribution: wazo-dev-bookworm
+wazo_distribution_upgrade: wazo-dev-bookworm
 wazo_meta_package: wazo-platform
 
 debian_repo_wazo__key_url: https://mirror.wazo.community/wazo_current.key

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -4,11 +4,11 @@
     wazo-check:
       jobs:
         - ansible-lint:
-            nodeset: pod-debian-11
+            nodeset: vm-debian-12-m1s
     wazo-gate:
       jobs:
         - ansible-lint:
-            nodeset: pod-debian-11
+            nodeset: vm-debian-12-m1s
     experimental:
       jobs:
         - wazo-acceptance-bookworm

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,6 +1,6 @@
 - project:
     templates:
-      - wazo-ansible-uc-bullseye
+      - wazo-ansible-uc-bookworm
     wazo-check:
       jobs:
         - ansible-lint:
@@ -11,4 +11,4 @@
             nodeset: pod-debian-11
     experimental:
       jobs:
-        - wazo-acceptance-bullseye
+        - wazo-acceptance-bookworm


### PR DESCRIPTION
- **use debian 12 key to validate repo**
- **use bookworm instead of bullseye**
- **remove bookworm specific steps**
- **zuul: use VM for lint instead of container**
